### PR TITLE
Removing the redundant file introduced

### DIFF
--- a/fs/tests/test_touch.py
+++ b/fs/tests/test_touch.py
@@ -26,6 +26,9 @@ def test_touch_on_new_file():
 
     assert os.path.exists(new_file) is True
 
+    os.remove(new_file)
+
+
 @pytest.mark.skipif(os.name == "nt", reason="does not work on windows")
 def test_touch_on_directory():
 


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_touch_on_new_file` by Removing the redundant file introduced by calling method `os.remove`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 fs/tests/test_touch.py::test_touch_on_new_file`:

```
    def test_touch_on_new_file():
    
        new_file = os.path.join(TEST_DIR, "new_file.txt")
    
        if (os.path.exists(new_file)):
>           raise ValueError("File new_file.txt already exists!")
E           ValueError: File new_file.txt already exists!
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
