### PR TITLE
fix flaky fs/tests/test_addpath.py::test_addpath

### DIFF
--- a/fs/tests/test_addpath.py
+++ b/fs/tests/test_addpath.py
@@ -1,5 +1,6 @@
 import fs
 import pytest
+import sys
 
 from .setup import *
 
@@ -14,6 +15,8 @@ def test_addpath():
 
   fs.addpath(TEST_DIR)
   import test_foo_bar
+  sys.path.remove(TEST_DIR)
+  del sys.modules['test_foo_bar']
 
 def test_addpath_not_existing_path():
   WRONG_TEST_DIR = 'foobartest'


### PR DESCRIPTION
This PR aims to fix the flaky test `fs/tests/test_addpath.py::test_addpath`. In previous versions, the test will run into failure when running for multiple times. And the reason is that `sys.path` and imported module didn't get reset. This can be fixed by clear status. The test failure can be reproduced by 
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 fs/tests/test_addpath.py::test_addpath`
Notice that the PR is modifying the test to make it more robust without changing the source code.